### PR TITLE
Added 'InstallDir' package parameter to vim-tux

### DIFF
--- a/vim-tux.install/tools/chocolateyinstall.ps1
+++ b/vim-tux.install/tools/chocolateyinstall.ps1
@@ -1,6 +1,10 @@
 ﻿$ErrorActionPreference = 'Stop'
 $toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 $destDir = Join-Path $ENV:ProgramFiles "Vim\vim80"
+if ($Env:ChocolateyPackageParameters -match '/InstallDir:\s*(.+)') {
+    $destDir = $Matches[1]
+    if ($destDir.StartsWith("'") -or $destDir.StartsWith('"')) {
+        $destDir = $destDir -replace '^.|.$' '' }
 $filePath = if ((Get-ProcessorBits 64) -and $env:chocolateyForceX86 -ne $true) {
        Write-Host "Installing 64 bit version" ; gi $toolsDir\*_x64.7z }
 else { Write-Host "Installing 32 bit version" ; gi $toolsDir\*_x32.7z }

--- a/vim-tux.portable/tools/chocolateyinstall.ps1
+++ b/vim-tux.portable/tools/chocolateyinstall.ps1
@@ -1,6 +1,10 @@
 ﻿$ErrorActionPreference = 'Stop'
 $toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 $destDir = Join-Path $toolsDir "vim80"
+if ($Env:ChocolateyPackageParameters -match '/InstallDir:\s*(.+)') {
+    $destDir = $Matches[1]
+    if ($destDir.StartsWith("'") -or $destDir.StartsWith('"')) {
+        $destDir = $destDir -replace '^.|.$' '' }
 $filePath = if ((Get-ProcessorBits 64) -and $env:chocolateyForceX86 -ne $true) {
        Write-Host "Installing 64 bit version" ; gi $toolsDir\*_x64.7z }
 else { Write-Host "Installing 32 bit version" ; gi $toolsDir\*_x32.7z }


### PR DESCRIPTION
Code from [`chocolatey-coreteampackages`][2]’ [`python2` package][1]. Added to
`vim-tux.portable` and `vim-tux.install`.

[1]: https://github.com/chocolatey/chocolatey-coreteampackages/blob/master/automatic/python2/tools/chocolateyInstall.ps1
[2]: https://github.com/chocolatey/chocolatey-coreteampackages